### PR TITLE
Add required extensions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ git clone https://github.com/ShinDarth/TC-Quest-Tracker.git
 
 then open the **TC-Quest-Tracker** folder, copy the file **config.php.dist**, rename the copy to **config.php** and edit it properly (it's quite commented).
 
+Make sure to enable pdo_mysql extension too, i.e. edit php.ini and uncomment ```extension=pdo_mysql``` row.
+
 ---
 
 #### Screenshot


### PR DESCRIPTION
I struggled long enough when setting up this project because the pdo_mysql extension was not enabled and nowhere it was specified to enable it.